### PR TITLE
Invoke ginkgo with default args from task

### DIFF
--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -5,7 +5,7 @@ Debug "$(gci env:* | sort-object name | Out-String)"
 Configure-Groot "$env:WINC_TEST_ROOTFS"
 Configure-Winc-Network delete
 
-ginkgo.exe -p -r --race --keep-going --randomize-suites --fail-on-pending
+Invoke-Expression "go run github.com/onsi/ginkgo/v2/ginkgo $args"
 if ($LastExitCode -ne 0) {
   throw "tests failed"
 }


### PR DESCRIPTION
Additionally, use go moduled ginkgo instead of the one on PATH, so that it will always remain up-to-date