### PR TITLE
Fix file/dir creation permissions

### DIFF
--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -54,11 +54,11 @@ func NewHelpers(wincBin, grootBin, grootImageStore, wincNetworkBin string, debug
 }
 
 func (h *Helpers) GenerateBundle(bundleSpec specs.Spec, bundlePath string) {
-	ExpectWithOffset(1, os.MkdirAll(bundlePath, 0666)).To(Succeed())
+	ExpectWithOffset(1, os.MkdirAll(bundlePath, 0755)).To(Succeed())
 	config, err := json.Marshal(&bundleSpec)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	configFile := filepath.Join(bundlePath, "config.json")
-	ExpectWithOffset(1, os.WriteFile(configFile, config, 0666)).To(Succeed())
+	ExpectWithOffset(1, os.WriteFile(configFile, config, 0644)).To(Succeed())
 }
 
 func (h *Helpers) CreateContainer(bundleSpec specs.Spec, bundlePath, containerId string) {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Addresses Gosec G306/302/301 errors by fixing file permissions.

On windows only the 0200 and 0400 bits matter, so this doesn't actually change anything to how it functions. However it makes it a lot less scary for tools + people to audit at file permissions.

Backward Compatibility
---------------
Breaking Change? no